### PR TITLE
Fixes indentation for podAnnotations

### DIFF
--- a/charts/part-db/templates/statefulset.yaml
+++ b/charts/part-db/templates/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
       labels: {{- include "app.labels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 4 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       {{- if .Values.image.pullSecrets }}


### PR DESCRIPTION
The `podAnnotations` field was rendered at the wrong indentation level and were always ignored.
I have tested the changes on my cluster. With the indentation of `8` the annotations are rendered.