### PR TITLE
Add StartupProbe - Resolve container rebooting 

### DIFF
--- a/charts/part-db/templates/statefulset.yaml
+++ b/charts/part-db/templates/statefulset.yaml
@@ -71,6 +71,11 @@ spec:
         ports:
         - name: http
           containerPort: 80
+        startupProbe:
+          tcpSocket:
+            port: 80
+          failureThreshold: 30
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
See https://github.com/Part-DB/helm-charts/issues/5 for more details.

This adds a startupProbe which prevents the liveliness probe from killing the container if it does not start within 10 seconds.

Relevant Documentation: 

- https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes

